### PR TITLE
Extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,23 @@ This plugin uses <a href="https://github.com/adaptech-cz/Tesseract4Android/"> Te
 You must add trained data and trained data config file to your assets directory.
 You can find additional language trained data files here <a href="https://github.com/tesseract-ocr/tessdata">Trained language files</a>
 
-add tessdata folder under assets folder, add tess_data.config.json file under assets folder. 
+add tessdata folder under assets folder, add tessdata_config.json file under assets folder:
+```
+{
+  "files": [
+    "eng.traineddata",
+    "<other_language>.traineddata"
+  ]
+}
+``` 
 
 Plugin assumes you have tessdata folder in your assets directory and defined in your pubspec.yaml 
 
 Check the contents of example/assets folder and example/pubspec.yaml
+
+## Usage
+Using is very simple:
+
+`String text = await TesseractOcr.extractText('/path/to/image', language: 'eng');`
+
+You can leave `laguage` empty, it will default to `'eng'`.


### PR DESCRIPTION
I fixed a typo: default config file is `tessdata_config.json`
Added simple example at the bottom